### PR TITLE
chore(release): 1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lagoni/asyncapi-quicktype-template",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@lagoni/asyncapi-quicktype-template",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "Template to generate type files with quicktype.",
 	"keywords": [
 		"asyncapi",


### PR DESCRIPTION
Version bump in package.json and package-lock.json for release [1.0.2](https://github.com/jonaslagoni/asyncapi-quicktype-template/releases/tag/v1.0.2)